### PR TITLE
Adopt Documenter 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,5 +16,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Documenter = "~0.23"
 julia = "^1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1.1.2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,16 +2,20 @@ using Documenter
 push!(LOAD_PATH,"../src/")
 using EmpiricalModeDecomposition
 
-makedocs(sitename="EmpiricalModeDecomposition.jl Documentation",
-        pages = [
-                 "Library" => [
-                    "Reference" => "reference.md",
-                    "Extras" => "extras.md",
-                    "Internals" => "internals.md"
-                    ],
-                "Methods" => "methods.md"
-              ]
-       )
+makedocs(;
+  sitename="EmpiricalModeDecomposition.jl",
+  checkdocs=:exports,
+  pages = Any[
+    "Home" => "index.md",
+    "Library" => [
+      "Reference" => "reference.md",
+      "Extras" => "extras.md",
+      "Internals" => "internals.md"
+    ],
+    "Methods" => "methods.md"
+  ]
+)
+
 deploydocs(
-           repo = "github.com/atmnpatel/EmpiricalModeDecomposition.jl.git"
+  repo = "github.com/atmnpatel/EmpiricalModeDecomposition.jl.git"
 )


### PR DESCRIPTION
This PR adjusts this package to use the new version of [`Documenter.jl`](https://github.com/JuliaDocs/Documenter.jl) since your configuration still uses an old version of it. After registering the new version of this package in the General registry, you may want to remove [`push!(LOAD_PATH,"../src/")`](https://github.com/atmnpatel/EmpiricalModeDecomposition.jl/blob/cc440f28ff047f45cc456cd02f95eb3429f2525a/docs/make.jl#L2C26-L2C26) since it's not needed anymore. The following snapshots show what the new documentation will look like. The picture on the left-hand side is related to the current documentation, and the picture on the right-hand side is related to the upcoming one.  
![msedge_TXrCwnWDd0](https://github.com/atmnpatel/EmpiricalModeDecomposition.jl/assets/52105833/20d54e83-268f-49bb-a0b6-3759d62c9a14)
![msedge_p5PmkYzlKM](https://github.com/atmnpatel/EmpiricalModeDecomposition.jl/assets/52105833/9a685f12-4460-4330-8860-46f8090ea775)
![msedge_8sMVbp9vrr](https://github.com/atmnpatel/EmpiricalModeDecomposition.jl/assets/52105833/4a38c33b-1be7-4164-b622-fb90a516f9f1)
![msedge_7ELNuBewQT](https://github.com/atmnpatel/EmpiricalModeDecomposition.jl/assets/52105833/84f184e4-3617-4eed-8a65-14f906d41e5a)
![msedge_BDPK5Wl2WI](https://github.com/atmnpatel/EmpiricalModeDecomposition.jl/assets/52105833/017b36dd-21f0-4e2b-bfa4-e35a5d0ac33a)
![msedge_fTMo5XTs2H](https://github.com/atmnpatel/EmpiricalModeDecomposition.jl/assets/52105833/92b794b9-92ff-466f-95fc-11584c09514b)
